### PR TITLE
Use www.redhat.com instead of redhat.com

### DIFF
--- a/test/initramfs/check-net.sh
+++ b/test/initramfs/check-net.sh
@@ -5,7 +5,7 @@ set -ex
 mkdir -p "/var/lib/dhcpcd"
 
 interfaces=( $(ip l | sed -n '/LOOPBACK/b;/^[0-9]\+/p' | awk -F ": " '{ print $2 }') )
-hosts=( 1.1.1.1 redhat.com )
+hosts=( 1.1.1.1 www.redhat.com )
 
 for netdev in "${interfaces[@]}"; do
     echo "Processing: ${netdev}"


### PR DESCRIPTION
`ping -c 4 redhat.com` did not work when I tested.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>