### PR TITLE
Use firewalld instead of sysctl and iptables

### DIFF
--- a/components/nat.sh
+++ b/components/nat.sh
@@ -5,22 +5,7 @@ set -e
 configure_nat() {
   log_info "Configuring NAT"
 
-  log_info "Enabling IP forwarding"
-  echo 'net.ipv4.ip_forward=1' > /etc/sysctl.conf
-  sysctl -p /etc/sysctl.conf
-
-  log_info "Enabling NAT masquerade"
-  switches=( $(ip route ls | \
-    awk '/^default / {
-          for(i=0;i<NF;i++) { if ($i == "dev") { print $(i+1); next; } }
-         }'
-        ) )
-
-  switch="${switches[0]}"
-  log_info "Selected external interface: ${switch}"
-
-  iptables -t nat -A POSTROUTING -o "${switch}" -j MASQUERADE
-
-  iptables -A FORWARD -i "${bridge}" -j ACCEPT
-  iptables -A FORWARD -o "${bridge}" -j ACCEPT
+  firewall-cmd -q --add-forward --permanent
+  firewall-cmd -q --add-masquerade --permanent
+  firewall-cmd -q --reload
 }


### PR DESCRIPTION
Unlike iptables, firewalld can persist the configuration as the other part of this setup does.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>

Ubuntu is problematic here because it does not have a mechanism that persists IP masquerading enabled. It can use firewalld, nftables or ufw, but they are not enabled and enabling them is likely to be very disruptive as it can introduce other firewall rules.

I'm increasingly feeling some container mechanism should be adopted to solve distribution incompatibility, disruptive nature of AutoHCK installation, and inconveniences caused by requiring root.